### PR TITLE
Clarify installation of CLI and library in `README`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,19 +43,24 @@ Current capabilities include:
 
 **Command line**
 
+To install the command line tool, use `cargo:
+
 ```bash
 cargo install --git https://github.com/JR-1991/rust-dataverse.git
 ```
 
-**Cargo.toml**
+After installation, you can interact with the Dataverse API using the dvcli command. Note that this command installs only the CLI tool, not the library itself. Instructions for adding the library to your project are provided below.
 
-Please note, this crate is not yet published on crates.io. You can add it to your `Cargo.toml` file by pointing to the
-GitHub repository.
+**Library**
+
+To include the library in your project, add this to your Cargo.toml file:
 
 ```toml
 [dependencies]
 dataverse = { git = "https://github.com/JR-1991/rust-dataverse" }
 ```
+
+Since the library isn’t published on [crates.io](https://crates.io) yet, we’re using a git dependency. Once added, you can begin using the library in your project.
 
 ## Usage
 


### PR DESCRIPTION
As noted in issue #6, the existing `README` does not clearly differentiate between the installation steps for the CLI and the library. This PR updates the `README` to provide clearer instructions on which commands to use for each scenario.

Closes #6